### PR TITLE
no-backport: Bumping verstion to 1.8.0.dev0 with gmatheu as prefix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "elia_chat"
-version = "1.7.0"
+version = "1.8.0.dev1+gmatheu"
 description = "A powerful terminal user interface for interacting with large language models."
 authors = [
     { name = "Darren Burns", email = "darrenb900@gmail.com" }


### PR DESCRIPTION
Adding a `.dev0` dev version with gmatheu as prefix